### PR TITLE
Fix encoding and line endings of Afrikaans translations

### DIFF
--- a/Resources/translations/date.af.xliff
+++ b/Resources/translations/date.af.xliff
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
@@ -58,7 +58,7 @@
             </trans-unit>
             <trans-unit id="date.tomorrow">
                 <source>date.tomorrow</source>
-                <target>môre</target>
+                <target>mÃ´re</target>
             </trans-unit>
             <trans-unit id="date.just_now">
                 <source>date.just_now</source>


### PR DESCRIPTION
File `Resources/translations/date.af.xliff is encoded in ISO-Latin1, which breaks on Symfony cache warmup. I changed it to UTF-8. I also changed the line endings from Windows to Unix.