### PR TITLE
Use $named argument in service definition

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,7 +9,7 @@ services:
     dms_twig_extension.fabpot.date:
         class: Twig_Extensions_Extension_Date
         arguments:
-            translator: "@translator"
+            $translator: "@translator"
 
     dms_twig_extension.fabpot.i18n:
         class: Twig_Extensions_Extension_I18n
@@ -24,6 +24,6 @@ services:
     dms_twig_extension.dms.textual_date:
         class: DMS\Bundle\TwigExtensionBundle\Twig\Date\TextualDateExtension
         arguments:
-            translator: "@translator"
+            $translator: "@translator"
     dms_twig_extension.dms.pad_string:
         class: DMS\Bundle\TwigExtensionBundle\Twig\Text\PadStringExtension


### PR DESCRIPTION
only integer or $named arguments are allowed as of Symfony 3.3